### PR TITLE
[FE][Integration] Add Dummy Leaderboard Data for Dummy Games

### DIFF
--- a/public/dummy-leaderboard.json
+++ b/public/dummy-leaderboard.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": 9999999,
+    "name": "Jasmine Avery",
+    "email": "jasmineavery@email.com",
+    "profile_pic": null,
+    "badge": "Platinum",
+    "points": 1000
+  },
+  {
+    "id": 9999999,
+    "name": "Keith Cornish",
+    "email": "keithcornish@email.com",
+    "profile_pic": null,
+    "badge": "Platinum",
+    "points": 900
+  },
+  {
+    "id": 9999999,
+    "name": "Dylan Manning",
+    "email": "dylanmanning@email.com",
+    "profile_pic": null,
+    "badge": "Platinum",
+    "points": 800
+  },
+  {
+    "id": 9999999,
+    "name": "Dylan Manning",
+    "email": "dylanmanning@email.com",
+    "profile_pic": null,
+    "badge": "Platinum",
+    "points": 700
+  },
+  {
+    "id": 9999999,
+    "name": "Adrian Murray",
+    "email": "adrianmurray@email.com",
+    "profile_pic": null,
+    "badge": "Platinum",
+    "points": 600
+  },
+  {
+    "id": 9999999,
+    "name": "Diane Dickens",
+    "email": "dianedickens@email.com",
+    "profile_pic": null,
+    "badge": "Gold",
+    "points": 500
+  },
+  {
+    "id": 9999999,
+    "name": "Nicola Sanderson",
+    "email": "nicolasanderson@email.com",
+    "profile_pic": null,
+    "badge": "Gold",
+    "points": 400
+  },
+  {
+    "id": 9999999,
+    "name": "Michelle Baker",
+    "email": "michellebaker@email.com",
+    "profile_pic": null,
+    "badge": "Gold",
+    "points": 300
+  },
+  {
+    "id": 9999999,
+    "name": "Victoria Lyman",
+    "email": "victorialyman@email.com",
+    "profile_pic": null,
+    "badge": "Bronze",
+    "points": 100
+  },
+  {
+    "id": 9999999,
+    "name": "Oliver Bower",
+    "email": "oliverbower@email.com",
+    "profile_pic": null,
+    "badge": "Bronze",
+    "points": 50
+  }
+]


### PR DESCRIPTION
## [FE][Integration] Add Dummy Leaderboard Data for Dummy Games

## Description
**DOD:**

- create `a seeder data` or `insert data to db manually` or `sql script` or `json in frontend`
- the table need to have dummy is in `game_histories` and `users` table. except the suit game game_id

- Trello Link: [here](https://trello.com/c/vVi47Ro5/45-2-to-make-dummy-data-leaderboard-for-game-dummy-beside-suit-game)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor/Breaking Change
